### PR TITLE
fix sddm-theme-6.0

### DIFF
--- a/sddm/6.0/Lavanda-Sea/Main.qml
+++ b/sddm/6.0/Lavanda-Sea/Main.qml
@@ -11,14 +11,10 @@ import Qt5Compat.GraphicalEffects
 
 import org.kde.plasma.components 3.0 as PlasmaComponents3
 import org.kde.plasma.plasma5support 2.0 as P5Support
+import org.kde.plasma.private.keyboardindicator as KeyboardIndicator
 import org.kde.kirigami 2.20 as Kirigami
 
 import org.kde.breeze.components
-
-// TODO: Once SDDM 0.19 is released and we are setting the font size using the
-// SDDM KCM's syncing feature, remove the `config.fontSize` overrides here and
-// the fontSize properties in various components, because the theme's default
-// font size will be correctly propagated to the login screen
 
 Item {
     id: root
@@ -38,10 +34,9 @@ Item {
     LayoutMirroring.enabled: Qt.application.layoutDirection === Qt.RightToLeft
     LayoutMirroring.childrenInherit: true
 
-    P5Support.DataSource {
-        id: keystateSource
-        engine: "keystate"
-        connectedSources: "Caps Lock"
+    KeyboardIndicator.KeyState {
+        id: capsLockState
+        key: Qt.Key_CapsLock
     }
 
     Item {
@@ -122,11 +117,13 @@ Item {
             id: clockShadow
             anchors.fill: clock
             source: clock
-            visible: !softwareRendering
-            radius: 6
-            samples: 14
-            spread: 0.3
-            color : "black" // shadows should always be black
+            visible: !softwareRendering && config.showClock === "true"
+            radius: 7
+            verticalOffset: 0.8
+            samples: 15
+            spread: 0.2
+            color : Qt.rgba(0, 0, 0, 0.7)
+            opacity: loginScreenRoot.uiVisible ? 0 : 1
             Behavior on opacity {
                 OpacityAnimator {
                     duration: Kirigami.Units.veryLongDuration * 2
@@ -138,7 +135,7 @@ Item {
         Clock {
             id: clock
             property Item shadow: clockShadow
-            visible: y > 0
+            visible: y > 0 && config.showClock === "true"
             anchors.horizontalCenter: parent.horizontalCenter
             y: (userListComponent.userList.y + mainStack.y)/2 - height/2
             Layout.alignment: Qt.AlignBaseline
@@ -175,7 +172,7 @@ Item {
             initialItem: Login {
                 id: userListComponent
                 userListModel: userModel
-                //loginScreenUiVisible: loginScreenRoot.uiVisible
+                loginScreenUiVisible: loginScreenRoot.uiVisible
                 userListCurrentIndex: userModel.lastIndex >= 0 ? userModel.lastIndex : 0
                 lastUserName: userModel.lastUser
                 showUserList: {
@@ -197,8 +194,8 @@ Item {
 
                 notificationMessage: {
                     const parts = [];
-                    if (keystateSource.data["Caps Lock"]["Locked"]) {
-                        parts.push(i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Caps Lock is on"));
+                    if (capsLockState.locked) {
+                        parts.push(i18nd("plasma-desktop-sddm-theme", "Caps Lock is on"));
                     }
                     if (root.notificationMessage) {
                         parts.push(root.notificationMessage);
@@ -209,32 +206,27 @@ Item {
                 actionItemsVisible: !inputPanel.keyboardActive
                 actionItems: [
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda-Sea/assets/suspend_primary.svgz"
-                        text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "Suspend to RAM", "Sleep")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda-Sea/assets/suspend_primary.svgz"
+                        text: i18ndc("plasma-desktop-sddm-theme", "Suspend to RAM", "Sleep")
                         onClicked: sddm.suspend()
                         enabled: sddm.canSuspend
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda-Sea/assets/restart_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Restart")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda-Sea/assets/restart_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "Restart")
                         onClicked: sddm.reboot()
                         enabled: sddm.canReboot
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda-Sea/assets/shutdown_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Shut Down")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda-Sea/assets/shutdown_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "Shut Down")
                         onClicked: sddm.powerOff()
                         enabled: sddm.canPowerOff
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda-Sea/assets/switch_primary.svgz"
-                        text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "For switching to a username and password prompt", "Other…")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda-Sea/assets/switch_primary.svgz"
+                        text: i18ndc("plasma-desktop-sddm-theme", "For switching to a username and password prompt", "Other…")
                         onClicked: mainStack.push(userPromptComponent)
-                        enabled: true
                         visible: !userListComponent.showUsernamePrompt
                     }]
 
@@ -329,8 +321,8 @@ Item {
             Login {
                 showUsernamePrompt: true
                 notificationMessage: root.notificationMessage
-                //loginScreenUiVisible: loginScreenRoot.uiVisible
-                fontSize: parseInt(config.fontSize) + 2
+                loginScreenUiVisible: loginScreenRoot.uiVisible
+                fontSize: Kirigami.Theme.defaultFont.pointSize + 2
 
                 // using a model rather than a QObject list to avoid QTBUG-75900
                 userListModel: ListModel {
@@ -340,7 +332,7 @@ Item {
                     }
                     Component.onCompleted: {
                         // as we can't bind inside ListElement
-                        setProperty(0, "name", i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Type in Username and Password"));
+                        setProperty(0, "name", i18nd("plasma-desktop-sddm-theme", "Type in Username and Password"));
                         setProperty(0, "icon", Qt.resolvedUrl("faces/.face.icon"))
                     }
                 }
@@ -353,30 +345,26 @@ Item {
                 actionItemsVisible: !inputPanel.keyboardActive
                 actionItems: [
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda-Sea/assets/suspend_primary.svgz"
-                        text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "Suspend to RAM", "Sleep")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda-Sea/assets/suspend_primary.svgz"
+                        text: i18ndc("plasma-desktop-sddm-theme", "Suspend to RAM", "Sleep")
                         onClicked: sddm.suspend()
                         enabled: sddm.canSuspend
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda-Sea/assets/restart_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Restart")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda-Sea/assets/restart_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "Restart")
                         onClicked: sddm.reboot()
                         enabled: sddm.canReboot
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda-Sea/assets/shutdown_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Shut Down")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda-Sea/assets/shutdown_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "Shut Down")
                         onClicked: sddm.powerOff()
                         enabled: sddm.canPowerOff
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda-Sea/assets/switch_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "List Users")
-                        fontSize: parseInt(config.fontSize) + 1
+                       icon.name: "/usr/share/sddm/themes/Lavanda-Sea/assets/switch_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "List Users")
                         onClicked: mainStack.pop()
                     }
                 ]
@@ -450,8 +438,7 @@ Item {
             PlasmaComponents3.ToolButton {
                 id: virtualKeyboardButton
 
-                text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "Button to show/hide virtual keyboard", "Virtual Keyboard")
-                font.pointSize: config.fontSize
+                text: i18ndc("plasma-desktop-sddm-theme", "Button to show/hide virtual keyboard", "Virtual Keyboard")
                 icon.name: inputPanel.keyboardActive ? "input-keyboard-virtual-on" : "input-keyboard-virtual-off"
                 onClicked: {
                     // Otherwise the password field loses focus and virtual keyboard
@@ -473,8 +460,6 @@ Item {
             KeyboardButton {
                 id: keyboardButton
 
-                font.pointSize: config.fontSize
-
                 onKeyboardLayoutChanged: {
                     // Otherwise the password field loses focus and virtual keyboard
                     // keystrokes get eaten
@@ -492,8 +477,6 @@ Item {
 
             SessionButton {
                 id: sessionButton
-
-                font.pointSize: config.fontSize
 
                 onSessionChanged: {
                     // Otherwise the password field loses focus and virtual keyboard
@@ -515,16 +498,14 @@ Item {
                 Layout.fillWidth: true
             }
 
-            Battery {
-                fontSize: config.fontSize
-            }
+            Battery {}
         }
     }
 
     Connections {
         target: sddm
         function onLoginFailed() {
-            notificationMessage = i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Login Failed")
+            notificationMessage = i18nd("plasma-desktop-sddm-theme", "Login Failed")
             footer.enabled = true
             mainStack.enabled = true
             userListComponent.userList.opacity = 1

--- a/sddm/6.0/Lavanda/Main.qml
+++ b/sddm/6.0/Lavanda/Main.qml
@@ -11,14 +11,10 @@ import Qt5Compat.GraphicalEffects
 
 import org.kde.plasma.components 3.0 as PlasmaComponents3
 import org.kde.plasma.plasma5support 2.0 as P5Support
+import org.kde.plasma.private.keyboardindicator as KeyboardIndicator
 import org.kde.kirigami 2.20 as Kirigami
 
 import org.kde.breeze.components
-
-// TODO: Once SDDM 0.19 is released and we are setting the font size using the
-// SDDM KCM's syncing feature, remove the `config.fontSize` overrides here and
-// the fontSize properties in various components, because the theme's default
-// font size will be correctly propagated to the login screen
 
 Item {
     id: root
@@ -38,10 +34,9 @@ Item {
     LayoutMirroring.enabled: Qt.application.layoutDirection === Qt.RightToLeft
     LayoutMirroring.childrenInherit: true
 
-    P5Support.DataSource {
-        id: keystateSource
-        engine: "keystate"
-        connectedSources: "Caps Lock"
+    KeyboardIndicator.KeyState {
+        id: capsLockState
+        key: Qt.Key_CapsLock
     }
 
     Item {
@@ -122,11 +117,13 @@ Item {
             id: clockShadow
             anchors.fill: clock
             source: clock
-            visible: !softwareRendering
-            radius: 6
-            samples: 14
-            spread: 0.3
-            color : "black" // shadows should always be black
+            visible: !softwareRendering && config.showClock === "true"
+            radius: 7
+            verticalOffset: 0.8
+            samples: 15
+            spread: 0.2
+            color : Qt.rgba(0, 0, 0, 0.7)
+            opacity: loginScreenRoot.uiVisible ? 0 : 1
             Behavior on opacity {
                 OpacityAnimator {
                     duration: Kirigami.Units.veryLongDuration * 2
@@ -138,7 +135,7 @@ Item {
         Clock {
             id: clock
             property Item shadow: clockShadow
-            visible: y > 0
+            visible: y > 0 && config.showClock === "true"
             anchors.horizontalCenter: parent.horizontalCenter
             y: (userListComponent.userList.y + mainStack.y)/2 - height/2
             Layout.alignment: Qt.AlignBaseline
@@ -175,7 +172,7 @@ Item {
             initialItem: Login {
                 id: userListComponent
                 userListModel: userModel
-                //loginScreenUiVisible: loginScreenRoot.uiVisible
+                loginScreenUiVisible: loginScreenRoot.uiVisible
                 userListCurrentIndex: userModel.lastIndex >= 0 ? userModel.lastIndex : 0
                 lastUserName: userModel.lastUser
                 showUserList: {
@@ -197,8 +194,8 @@ Item {
 
                 notificationMessage: {
                     const parts = [];
-                    if (keystateSource.data["Caps Lock"]["Locked"]) {
-                        parts.push(i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Caps Lock is on"));
+                    if (capsLockState.locked) {
+                        parts.push(i18nd("plasma-desktop-sddm-theme", "Caps Lock is on"));
                     }
                     if (root.notificationMessage) {
                         parts.push(root.notificationMessage);
@@ -209,32 +206,27 @@ Item {
                 actionItemsVisible: !inputPanel.keyboardActive
                 actionItems: [
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda/assets/suspend_primary.svgz"
-                        text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "Suspend to RAM", "Sleep")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda/assets/suspend_primary.svgz"
+                        text: i18ndc("plasma-desktop-sddm-theme", "Suspend to RAM", "Sleep")
                         onClicked: sddm.suspend()
                         enabled: sddm.canSuspend
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda/assets/restart_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Restart")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda/assets/restart_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "Restart")
                         onClicked: sddm.reboot()
                         enabled: sddm.canReboot
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda/assets/shutdown_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Shut Down")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda/assets/shutdown_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "Shut Down")
                         onClicked: sddm.powerOff()
                         enabled: sddm.canPowerOff
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda/assets/switch_primary.svgz"
-                        text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "For switching to a username and password prompt", "Other…")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda/assets/switch_primary.svgz"
+                        text: i18ndc("plasma-desktop-sddm-theme", "For switching to a username and password prompt", "Other…")
                         onClicked: mainStack.push(userPromptComponent)
-                        enabled: true
                         visible: !userListComponent.showUsernamePrompt
                     }]
 
@@ -329,8 +321,8 @@ Item {
             Login {
                 showUsernamePrompt: true
                 notificationMessage: root.notificationMessage
-                //loginScreenUiVisible: loginScreenRoot.uiVisible
-                fontSize: parseInt(config.fontSize) + 2
+                loginScreenUiVisible: loginScreenRoot.uiVisible
+                fontSize: Kirigami.Theme.defaultFont.pointSize + 2
 
                 // using a model rather than a QObject list to avoid QTBUG-75900
                 userListModel: ListModel {
@@ -340,7 +332,7 @@ Item {
                     }
                     Component.onCompleted: {
                         // as we can't bind inside ListElement
-                        setProperty(0, "name", i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Type in Username and Password"));
+                        setProperty(0, "name", i18nd("plasma-desktop-sddm-theme", "Type in Username and Password"));
                         setProperty(0, "icon", Qt.resolvedUrl("faces/.face.icon"))
                     }
                 }
@@ -353,30 +345,26 @@ Item {
                 actionItemsVisible: !inputPanel.keyboardActive
                 actionItems: [
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda/assets/suspend_primary.svgz"
-                        text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "Suspend to RAM", "Sleep")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda/assets/suspend_primary.svgz"
+                        text: i18ndc("plasma-desktop-sddm-theme", "Suspend to RAM", "Sleep")
                         onClicked: sddm.suspend()
                         enabled: sddm.canSuspend
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda/assets/restart_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Restart")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda/assets/restart_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "Restart")
                         onClicked: sddm.reboot()
                         enabled: sddm.canReboot
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda/assets/shutdown_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Shut Down")
-                        fontSize: parseInt(config.fontSize) + 1
+                        icon.name: "/usr/share/sddm/themes/Lavanda/assets/shutdown_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "Shut Down")
                         onClicked: sddm.powerOff()
                         enabled: sddm.canPowerOff
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Lavanda/assets/switch_primary.svgz"
-                        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "List Users")
-                        fontSize: parseInt(config.fontSize) + 1
+                       icon.name: "/usr/share/sddm/themes/Lavanda/assets/switch_primary.svgz"
+                        text: i18nd("plasma-desktop-sddm-theme", "List Users")
                         onClicked: mainStack.pop()
                     }
                 ]
@@ -450,8 +438,7 @@ Item {
             PlasmaComponents3.ToolButton {
                 id: virtualKeyboardButton
 
-                text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "Button to show/hide virtual keyboard", "Virtual Keyboard")
-                font.pointSize: config.fontSize
+                text: i18ndc("plasma-desktop-sddm-theme", "Button to show/hide virtual keyboard", "Virtual Keyboard")
                 icon.name: inputPanel.keyboardActive ? "input-keyboard-virtual-on" : "input-keyboard-virtual-off"
                 onClicked: {
                     // Otherwise the password field loses focus and virtual keyboard
@@ -473,8 +460,6 @@ Item {
             KeyboardButton {
                 id: keyboardButton
 
-                font.pointSize: config.fontSize
-
                 onKeyboardLayoutChanged: {
                     // Otherwise the password field loses focus and virtual keyboard
                     // keystrokes get eaten
@@ -492,8 +477,6 @@ Item {
 
             SessionButton {
                 id: sessionButton
-
-                font.pointSize: config.fontSize
 
                 onSessionChanged: {
                     // Otherwise the password field loses focus and virtual keyboard
@@ -515,16 +498,14 @@ Item {
                 Layout.fillWidth: true
             }
 
-            Battery {
-                fontSize: config.fontSize
-            }
+            Battery {}
         }
     }
 
     Connections {
         target: sddm
         function onLoginFailed() {
-            notificationMessage = i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Login Failed")
+            notificationMessage = i18nd("plasma-desktop-sddm-theme", "Login Failed")
             footer.enabled = true
             mainStack.enabled = true
             userListComponent.userList.opacity = 1

--- a/sddm/6.0/README.md
+++ b/sddm/6.0/README.md
@@ -1,5 +1,5 @@
 
-McMojave sddm theme for KDE Plasma desktop.
+Lavanda sddm theme for KDE Plasma desktop.
 
 ## Installation
 


### PR DESCRIPTION

## Environment

| Name              | Version   |
| ----------------- | --------- |
| kde-plasma        | `6.3.4`   |
| sddm              | `0.21.0`  |
| sddm-greeter-qt6  | `0.21.0`  |


## Issue

I noticed that applying `sddm/6.0/Lavanda` and `sddm/6.0/Lavanda-Sea` resulted in an error message about `fontSize`.

So I made the following adjustments, and now I can successfully apply these two `SDDM Themes`.




## Adjustment


### Lavanda

* Copy [Colloid-kde/sddm/6.0/Colloid/Main.qml](https://github.com/vinceliuice/Colloid-kde/blob/main/sddm/6.0/Colloid/Main.qml) to [Lavanda-kde/sddm/6.0/Lavanda/Main.qml](https://github.com/vinceliuice/Lavanda-kde/blob/main/sddm/6.0/Lavanda/Main.qml)
* Change `Colloid` to `Lavanda`


### Lavanda-kde

* Copy [Colloid-kde/sddm/6.0/Colloid/Main.qml](https://github.com/vinceliuice/Colloid-kde/blob/main/sddm/6.0/Colloid/Main.qml) to [Lavanda-kde/sddm/6.0/Lavanda-Sea/Main.qml](https://github.com/vinceliuice/Lavanda-kde/blob/main/sddm/6.0/Lavanda-Sea/Main.qml)
* Change `Colloid` to `Lavanda-Sea`


### README.md

* Edit [Lavanda-kde/sddm/6.0/README.md](https://github.com/vinceliuice/Lavanda-kde/blob/main/sddm/6.0/README.md)
* Change `McMojave` to `Lavanda`
